### PR TITLE
configure npm and yarn to default to public registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+access = "public"
+registry = "https://registry.npmjs.org"
+

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org"


### PR DESCRIPTION
whether someone chooses to use `npm` or `yarn` when publishing, the configuration should default to using the public registry and publish as public