### PR TITLE
loadable functionality for readable/writable stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.2.0 (2022-07-09)
+
+- *BREAKING CHANGE* feat: add load functionality to readable/writable stores
+  - readable and writable stores now include a `load` function, the same as the other stores.
+  - This load function resolves when the store is first `set`.
+  - If the store is given an initial value that is not undefined, it will `load` immeadietly.
+  - How this might break your app: derived / asyncDerived stores only `load` after every parent has loaded. If you derive from a readable or writable store, the derived store will now only load after the readable or writable store has loaded.
+  - How to migrate: If you want a readable / writable store to load before it has been given a final value, initialize the store with a value of 'null' rather than undefined.
+
+## <small>0.1.5 (2022-06-16)</small>
+
+- feat: safeLoad function for catching load errors
+
 ## <small>0.1.3 (2022-05-08)</small>
 
 - fix: remove non-functional isLoading property

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/svelte-store",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/svelte-store",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["../test/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "inlineSources": true,
     "target": "ES6",
     "moduleResolution": "node",
-    "module": "es2022"
+    "module": "es2022",
+    "strict": false,
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "public/*"],


### PR DESCRIPTION
This adds load functionality to readable/writable stores. They both include load functions that give you a promise that resolves when the store is first `set` (either through their start function, or through being set externally)

This lets you delay application steps that need to happen after these stores get a value, without forcing you to use promises/async functions to load the store like you need to do for async stores.

Simple example:
```
<script>
  const hasConsent = writable(undefined, (set) => {
    const setConsent = set(true);
    addEventListener('CONSENT_EVENT', setConsent);

    return () => removeEventListener('CONSENT_EVENT', setConsent);  
  });
  const needsConsent = asyncDerived(
    (hasConsent),
    async ($hasConsent) => {
      // this won't run until hasConsent has loaded
      if (!$hasConsent) {
        return "no consent given"
      }
      const asyncMessage = await Promise.resolve('data fetched from server');
      return asyncMessage;
    }
  );
</script>

<button on:click={() => hasConsent.set(true)>I consent!</button>
<button on:click={() => hasConsent.set(false)>I don't consent!</button>

{#await needsConsent.load()}
  <p>I will only load after hasConsent has been populated</p>
  <p>{$needsConsent}</p>
{/await}
```
Note how, unlike async stores, we can return an unsubscribe function to clean up the event listener when this component is destroyed. 

Previous points of disucssion, before I decided to move forward having these replace readable/writable stores
```
One area of discussion: Should these be separate stores? Or should they supplant default `readable` and `writable` stores  (like we do for derived, by reexporting).

The three main benefits of replacing readable and writable are that 
  1. it allows for this behavior by default when switching over to @square/svelte-store without needing to update a bunch of stores
  2. It reduces the number of new store types that this package exports, simplifying our documentation and reducing the spin up time of learning when to use these different stores. 
  3. It means that *every* store is loadable, which allows us to simplify the typing and logic surrounding that. 
  
 
 The two possible downsides are:
 1. added memory consumption and complexity to all readable and wrtitable stores
 2. It is possible this could break some people's apps--If someone creates an store with an undefined value and then never sets it to a different value, then the store will never 'load' and thus will block anything that relies on that completing (like asyncDerived stores) 
 ```
 
 This is a potentially breaking change, so I am bumping the version to 0.2.0
 Example break in stores/messages.ts
 
 unreadMessageCount derives from an asynchronous source, and from a readable source. When updatedMessageCount (set by the event listener) has a value, that value is used instead of the initializedMessageCount. Since updatedMessageCount starts as undefined, it will not 'load' until the event listener fires. This means that unreadMessageCount will not load until then either, which is not the intended behavior.
 
 This is fixed in 0.2.0 by providing 'null' as the initial value of the updatedMessageCount store instead of 'undefined'  