### PR TITLE
fix: writable with single parent calls setter with array

### DIFF
--- a/src/async-stores/index.ts
+++ b/src/async-stores/index.ts
@@ -203,7 +203,8 @@ export const asyncWritable = <S extends Stores, T>(
 
         const writeResponse = (await mappingWriteFunction(
           newValue,
-          parentValues,
+          // if mappingWriteFunction takes in single store rather than array, give it first value
+          Array.isArray(stores) ? parentValues : parentValues[0],
           oldValue
         )) as T;
 

--- a/test/async-stores/index.test.ts
+++ b/test/async-stores/index.test.ts
@@ -636,7 +636,10 @@ describe('asyncWritable', () => {
         (storeValue) => `derived from ${storeValue}`,
         (value, $asyncReadableParent) =>
           Promise.resolve(
-            `constructed from ${value} and ${$asyncReadableParent}`
+            `constructed from ${value} and ${JSON.stringify(
+              $asyncReadableParent
+              // remove leading and trailing quotes
+            ).slice(1, -1)}`
           )
       );
       myAsyncWritable.subscribe(jest.fn);

--- a/test/async-stores/index.test.ts
+++ b/test/async-stores/index.test.ts
@@ -636,10 +636,7 @@ describe('asyncWritable', () => {
         (storeValue) => `derived from ${storeValue}`,
         (value, $asyncReadableParent) =>
           Promise.resolve(
-            `constructed from ${value} and ${JSON.stringify(
-              $asyncReadableParent
-              // remove leading and trailing quotes
-            ).slice(1, -1)}`
+            `constructed from ${value} and ${$asyncReadableParent}`
           )
       );
       myAsyncWritable.subscribe(jest.fn);
@@ -648,6 +645,34 @@ describe('asyncWritable', () => {
       expect(get(myAsyncWritable)).toBe(
         'constructed from set value and first value'
       );
+    });
+
+    it('provides a single asyncReadable parent value if parent is not an array', async () => {
+      const asyncReadableParent = asyncReadable(undefined, mockReload);
+      const myAsyncWritable = asyncWritable(
+        asyncReadableParent,
+        (storeValue) => `derived from ${storeValue}`,
+        (_, $asyncReadableParent) =>
+          Promise.resolve(`${typeof $asyncReadableParent}`)
+      );
+      myAsyncWritable.subscribe(jest.fn);
+
+      await myAsyncWritable.set('set value');
+      expect(get(myAsyncWritable)).toBe('string');
+    });
+
+    it('provides an array as parent value if asyncReadable has a parents array', async () => {
+      const asyncReadableParent = asyncReadable(undefined, mockReload);
+      const myAsyncWritable = asyncWritable(
+        [asyncReadableParent],
+        (storeValue) => `derived from ${storeValue}`,
+        (_, $asyncReadableParent) =>
+          Promise.resolve(`is an array: ${Array.isArray($asyncReadableParent)}`)
+      );
+      myAsyncWritable.subscribe(jest.fn);
+
+      await myAsyncWritable.set('set value');
+      expect(get(myAsyncWritable)).toBe('is an array: true');
     });
 
     it('reloads reloadable parent', async () => {


### PR DESCRIPTION
if asyncWritable has only a single parent rather than an array
of parents, it still passes an array of length 1 to the setter
function. this was not caught in testing because a template string
like `${['single value']}` is rendered as 'single value'