### PR TITLE
chore: add type guards to output of loadable checks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export interface Loadable<T> extends Readable<T> {
   flagForReload?(): void;
 }
 
+export interface Reloadable<T> extends Loadable<T> {
+  reload(): Promise<T>;
+}
+
 export interface AsyncWritable<T> extends Writable<T> {
   set(value: T, persist?: boolean): Promise<void>;
   update(updater: Updater<T>): Promise<void>;
@@ -67,7 +71,7 @@ const getStoresArray = (stores: Stores): Readable<unknown>[] => {
 export const isLoadable = <T>(object: unknown): object is Loadable<T> =>
   Object.prototype.hasOwnProperty.call(object, 'load');
 
-export const isReloadable = <T>(object: unknown): object is Loadable<T> =>
+export const isReloadable = <T>(object: unknown): object is Reloadable<T> =>
   Object.prototype.hasOwnProperty.call(object, 'reload');
 
 export const anyLoadable = (stores: Stores): boolean =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,10 +64,10 @@ const getStoresArray = (stores: Stores): Readable<unknown>[] => {
   return Array.isArray(stores) ? stores : [stores];
 };
 
-export const isLoadable = (object: unknown): boolean =>
+export const isLoadable = <T>(object: unknown): object is Loadable<T> =>
   Object.prototype.hasOwnProperty.call(object, 'load');
 
-export const isReloadable = (object: unknown): boolean =>
+export const isReloadable = <T>(object: unknown): object is Loadable<T> =>
   Object.prototype.hasOwnProperty.call(object, 'reload');
 
 export const anyLoadable = (stores: Stores): boolean =>


### PR DESCRIPTION
Adds better [type guards](https://www.typescriptlang.org/docs/handbook/advanced-types.html#typeof-type-guards) to the output of `isLoadable` and `isReloadable` so we can later infer the type of what was checked

Example
![2022-09-07 11 36 54](https://user-images.githubusercontent.com/10713193/188920186-7205e54c-6ad1-4ba9-adc7-ed98f14209e4.gif)
