### PR TITLE
feat: tracked state now provides booleans instead of string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@square/svelte-store",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
feat: tracked state now provides booleans instead of string

until now tracked state stores held a string. This could be used in templates to check the state of the stores by comparing to a string. But that comparison had to be made every time and resulted in verbose checks when trying to see if the store was in one of several states (checking if loading or reloading, for example)

This PR changes it so instead those comparisons are made when the state is updated and provided as boolean properties of the store's value. 

before:

```
{#if $myState === 'LOADING' || $myState === 'RELOADING'}
  //render something
{/if}
```

after:

```
{#if $myState.isPending}
  // render something
{/if}
```