### PR TITLE
reloading child with mutliple routes to ancestor now reloads ancestor once

### DIFF
--- a/src/async-stores/index.ts
+++ b/src/async-stores/index.ts
@@ -7,6 +7,7 @@ import type {
   Stores,
   StoresValues,
   WritableLoadable,
+  VisitedMap,
 } from './types';
 import { anyReloadable, getStoresArray, reloadAll, loadAll } from '../utils';
 
@@ -232,9 +233,14 @@ export const asyncWritable = <S extends Stores, T>(
   // // optional properties
   const hasReloadFunction = Boolean(reloadable || anyReloadable(stores));
   const reload = hasReloadFunction
-    ? async () => {
+    ? async (visitedMap?: VisitedMap) => {
+        const visitMap = visitedMap ?? new WeakMap();
+        const reloadAndTrackVisits = (stores: S) => reloadAll(stores, visitMap);
         setState('RELOADING');
-        const result = await loadDependenciesThenSet(reloadAll, reloadable);
+        const result = await loadDependenciesThenSet(
+          reloadAndTrackVisits,
+          reloadable
+        );
         setState('LOADED');
         return result;
       }

--- a/src/async-stores/types.ts
+++ b/src/async-stores/types.ts
@@ -12,16 +12,18 @@ export type LoadState = {
   isSettled: boolean; // LOADED or ERROR
 };
 
+export type VisitedMap = WeakMap<Readable<unknown>, Promise<unknown>>;
+
 export interface Loadable<T> extends Readable<T> {
   load(): Promise<T>;
-  reload?(): Promise<T>;
+  reload?(visitedMap?: VisitedMap): Promise<T>;
   state?: Readable<LoadState>;
   reset?(): void;
   store: Loadable<T>;
 }
 
 export interface Reloadable<T> extends Loadable<T> {
-  reload(): Promise<T>;
+  reload(visitedMap?: VisitedMap): Promise<T>;
 }
 
 export interface AsyncWritable<T> extends Writable<T> {

--- a/test/async-stores/index.test.ts
+++ b/test/async-stores/index.test.ts
@@ -166,6 +166,24 @@ describe('asyncWritable', () => {
       expect(myAsyncDerived.load()).resolves.toBe('derived from second value');
     });
 
+    it('reloads once when children reload', async () => {
+      const asyncReadableParent = asyncReadable(undefined, mockReload, {
+        reloadable: true,
+      });
+      const childA = derived(asyncReadableParent, (storeValue) => storeValue);
+      const childB = derived(asyncReadableParent, (storeValue) => storeValue);
+      const grandChild = derived(
+        [childA, childB],
+        ([$childA, $childB]) => $childA + $childB
+      );
+
+      await grandChild.load();
+      expect(get(grandChild)).toBe('first valuefirst value');
+      await grandChild.reload();
+      expect(get(grandChild)).toBe('second valuesecond value');
+      expect(mockReload).toHaveBeenCalledTimes(2);
+    });
+
     it('rejects load when parent load fails', () => {
       const asyncReadableParent = asyncReadable(undefined, () =>
         Promise.reject(new Error('error'))

--- a/test/utils/index.test.ts
+++ b/test/utils/index.test.ts
@@ -55,6 +55,14 @@ describe('loadAll / reloadAll utils', () => {
         new Error('F')
       );
     });
+
+    it('does not reload already visited store', () => {
+      const visitedMap = new WeakMap();
+      visitedMap.set(myReloadable, Promise.resolve('already reloaded'));
+      expect(reloadAll(myReloadable, visitedMap)).resolves.toStrictEqual([
+        'already reloaded',
+      ]);
+    });
   });
 
   describe('safeLoad function', () => {


### PR DESCRIPTION
This fixes a bug that caused a reloadable ancestor to reload multiple times under some conditions when a descendant store was reloaded.

The bug was encountered when a store had multiple parents that each had the same reloadable store as an ancestor. This would create multiple paths in the chain of store reloads to this ancestor causing it to reload once for every unique path to that store. 

Ultimately this is a problem with reload because unlike loading it is not idempotent. Multiple calls to load a store will all return the same load promise, while reloading a reloadable store will generate new promises. So this PR adds some infrastructure so that multiple reload calls from the same source will return a single promise like loading does. This is done by generating a WeakMap of each visited store to its reload promise. This WeakMap is generated when reload is first called and then passed up the chain of ancestors via each store's reload function. When a store reloads its parents using reloadAll, each parent is checked for inclusion in the WeakMap and if its present the existing reload promise is returned instead of generating a new one. 

This has the side effect of letting you call reloadAll on multiple stores to associate all with a single WeakMap, allowing you to prevent any shared ancestors from being reloaded multiple times. 