### PR TITLE
fix: 'in' operator now returns correct value for asycClient

### DIFF
--- a/src/async-client/index.ts
+++ b/src/async-client/index.ts
@@ -1,5 +1,6 @@
 import { Loadable, StoresValues } from '../async-stores/types';
 import { AsyncClient } from './types';
+import { get } from 'svelte/store';
 
 /**
  * Generates an AsyncClient from a Loadable store. The AsyncClient will have all
@@ -47,6 +48,31 @@ export const asyncClient = <S extends Loadable<unknown>>(
         return Reflect.apply(storeValue, storeValue, argumentsList);
       }
       return storeValue;
+    },
+    has: (proxiedFunction, property) => {
+      const proxiedFunctionHasProperty: boolean =
+        Object.prototype.hasOwnProperty.call(proxiedFunction, property);
+
+      if (proxiedFunctionHasProperty) {
+        return proxiedFunctionHasProperty;
+      }
+
+      const loadableHasProperty: boolean = Object.prototype.hasOwnProperty.call(
+        loadable,
+        property
+      );
+
+      if (loadableHasProperty) {
+        return loadableHasProperty;
+      }
+
+      const value = get(loadable);
+
+      if (value) {
+        return Object.prototype.hasOwnProperty.call(value, property);
+      }
+
+      return false;
     },
   }) as unknown as S & AsyncClient<StoresValues<S>>;
 };

--- a/test/async-client/index.test.ts
+++ b/test/async-client/index.test.ts
@@ -30,4 +30,14 @@ describe('asyncClient', () => {
     const result = await resultPromise;
     expect(result).toBe('input + output');
   });
+
+  it("correctly identifies the existence of properties with the 'in' operator", () => {
+    const myClient = asyncClient(writable<unknown>());
+
+    expect('foo' in myClient).toBe(false);
+
+    myClient.set({ foo: true });
+
+    expect('foo' in myClient).toBe(true);
+  });
 });


### PR DESCRIPTION
# Description
Currently, the [in operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in) always returns false for `asyncClient`s.

Vitest's dependency, tinyspy, asserts that a property is `in` and object when attempting to spy on it, so `asyncClient`s are currently not spyable in that environment.

Offending code: https://github.com/tinylibs/tinyspy/blob/main/src/spyOn.ts#L78-L81