### PR TITLE
feat: store promise error in the state

### DIFF
--- a/src/async-stores/types.ts
+++ b/src/async-stores/types.ts
@@ -10,6 +10,7 @@ export type LoadState = {
   isError: boolean;
   isPending: boolean; // LOADING or RELOADING
   isSettled: boolean; // LOADED or ERROR
+  error: any | null; // if promise rejected, this will contain the error object
 };
 
 export type VisitedMap = WeakMap<Readable<unknown>, Promise<unknown>>;


### PR DESCRIPTION
This is a non-breaking change to include error value into the store state, if any.