### PR TITLE
peerDependencies compatible with npm/pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cookie-storage": "^6.1.0"
   },
   "peerDependencies": {
-    "svelte": ">= 3.0.0 < 5.0.0"
+    "svelte": "^3.0.0 || ^4.0.0"
   },
   "license": "ISC",
   "author": "Square",


### PR DESCRIPTION
When attempting to install @square/svelte-store@1.0.17 alongside svelte@4.2.1 using npm or pnpm, I encountered a dependency resolution error.

However, the installation succeeds without issues using yarn or bun. Despite svelte@4.2.1 seemingly being within the valid range specified by @square/svelte-store's peerDependencies, this issue persists.